### PR TITLE
Allow to specifiy multiple endpoints and loadbalance requests between them

### DIFF
--- a/core/src/main/java/org/operationcrypto/hivej/communication/AbstractClient.java
+++ b/core/src/main/java/org/operationcrypto/hivej/communication/AbstractClient.java
@@ -17,7 +17,6 @@
 package org.operationcrypto.hivej.communication;
 
 import java.io.IOException;
-import java.net.URI;
 
 import org.operationcrypto.hivej.jrpc.JsonRPCRequest;
 import org.operationcrypto.hivej.jrpc.JsonRPCResponse;
@@ -27,21 +26,22 @@ import org.operationcrypto.hivej.jrpc.JsonRPCResponse;
  * 
  * @author <a href="https://github.com/marvin-we">marvin-we</a>
  */
-public interface AbstractClient {
+public abstract class AbstractClient {
+    /**
+     * The endpoint this client communicates to.
+     */
+    private Endpoint endpoint;
+
     /**
      * Use this method to send a <code>requestObject</code> to the
-     * <code>endpointUri</code> and to receive an answer.
+     * <code>endpointUrl</code> and to receive an answer.
      * 
-     * @param requestObject           The object to send.
-     * @param endpointUri             The endpoint to connect and send to.
-     * @param sslVerificationDisabled Define if the SSL verification should be
-     *                                disabled.
+     * @param requestObject The object to send.
      * @return The response returned by the HiveJ Node wrapped in a
      *         {@link JsonRPCResponse} object.
      * @throws Exception In case of communication problems.
      */
-    public abstract JsonRPCResponse invokeAndReadResponse(JsonRPCRequest requestObject, URI endpointUri,
-            boolean sslVerificationDisabled) throws Exception;
+    public abstract JsonRPCResponse invokeAndReadResponse(JsonRPCRequest requestObject) throws Exception;
 
     /**
      * Use this method to close the connection of this client.
@@ -49,4 +49,22 @@ public interface AbstractClient {
      * @throws IOException If the connection can't be closed.
      */
     public abstract void closeConnection() throws IOException;
+
+    /**
+     * Get the endpoint used by this client.
+     * 
+     * @return The endpoint this client communicates to.
+     */
+    public Endpoint getEndpoint() {
+        return endpoint;
+    }
+
+    /**
+     * Define the endpoint used by this client.
+     * 
+     * @param endpoint The endpoint this client communicates to.
+     */
+    public void setEndpoint(Endpoint endpoint) {
+        this.endpoint = endpoint;
+    }
 }

--- a/core/src/main/java/org/operationcrypto/hivej/communication/CommunicationHandler.java
+++ b/core/src/main/java/org/operationcrypto/hivej/communication/CommunicationHandler.java
@@ -16,6 +16,7 @@
  */
 package org.operationcrypto.hivej.communication;
 
+import java.io.IOException;
 import java.util.List;
 
 import com.fasterxml.jackson.core.Version;
@@ -69,11 +70,14 @@ public class CommunicationHandler {
                 JavaType expectedResultType = mapper.getTypeFactory().constructCollectionType(List.class, targetClass);
                 return rawJsonResponse.handleResult(expectedResultType, requestObject.getId());
             }
-        } catch (Exception e) {
+        } catch (IOException e) {
             LOGGER.warn("The connection has been closed. Switching the endpoint and reconnecting.");
             LOGGER.debug("For the following reason: ", e);
             // Retry the request.
             return performRequest(requestObject, targetClass);
+        } catch (Exception e) {
+            LOGGER.debug("Unable to send request for an unknown reason.", e);
+            throw e;
         }
     }
 

--- a/core/src/main/java/org/operationcrypto/hivej/communication/ConnectionManager.java
+++ b/core/src/main/java/org/operationcrypto/hivej/communication/ConnectionManager.java
@@ -1,0 +1,138 @@
+/*
+ *     This file is part of HiveJ
+ * 
+ *     HiveJ is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * 
+ *     HiveJ is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ * 
+ *     You should have received a copy of the GNU General Public License
+ *     along with HiveJ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.operationcrypto.hivej.communication;
+
+import java.io.IOException;
+import java.security.InvalidParameterException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class manages connections. Pools LoadBalance
+ * 
+ * @author <a href="https://github.com/marvin-we">marvin-we</a>
+ */
+public class ConnectionManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConnectionManager.class);
+
+    // The singleton.
+    private static ConnectionManager sConnectionManager;
+
+    /** A pointer to the next client to use. */
+    private int nextClient;
+    /** The list of endpoints known to the ConnectionManager. */
+    private CopyOnWriteArrayList<AbstractClient> clients;
+
+    /**
+     * Create a new <code>ConnectionManager</code>.
+     */
+    private ConnectionManager() {
+        this.nextClient = 0;
+        this.clients = new CopyOnWriteArrayList<>();
+    }
+
+    /**
+     * Returns the singleton instance HiveJConfigurationObject
+     * 
+     * @return HiveJConfig
+     */
+    public static ConnectionManager getInstance() {
+        if (sConnectionManager == null) {
+            sConnectionManager = new ConnectionManager();
+        }
+        return sConnectionManager;
+    }
+
+    /**
+     * Add a new Client to the ConnectionManager.
+     * 
+     * @param endpoint The endpoint for which a client should be created.
+     * @throws Exception In case the client could not be initialized.
+     */
+    public void addClient(Endpoint endpoint) throws Exception {
+        if (endpoint.getEndpointURL().getProtocol().toLowerCase().matches("(http){1}[s]?")) {
+            this.clients.add(new HttpClient(endpoint));
+        } else {
+            throw new InvalidParameterException("No client implementation for the following protocol available: "
+                    + endpoint.getEndpointURL().getProtocol().toLowerCase());
+        }
+    }
+
+    /**
+     * Remove a client from the list of clients managed by this
+     * <code>ConnectionManager</code>.
+     * 
+     * @param endpoint The endpoint of which the client to remove is responsible
+     *                 for.
+     * @return The number of clients whose have been identified for the given
+     *         <code>endpoint</code> and have been removed.
+     */
+    public int removeClient(Endpoint endpoint) {
+        int numberOfRemovedEndpoints = 0;
+        // Find the client responsible for the given endpoint.
+        for (AbstractClient client : clients) {
+            if (endpoint.equals(client.getEndpoint())) {
+                // Close it's connection.
+                try {
+                    client.closeConnection();
+                } catch (IOException e) {
+                    LOGGER.error("Unable to close the connection.", e);
+                }
+                // Remove the client from the list of managed clients.
+                clients.remove(client);
+                // Raise the number of removed endpoints.
+                numberOfRemovedEndpoints++;
+            }
+        }
+        return numberOfRemovedEndpoints;
+    }
+
+    /**
+     * Get one of the clients managed by the <code>ConnectionManager</code>. The
+     * <code>ConnectionManager</code> uses the Round-Robin load balancing mechanism.
+     * 
+     * @return
+     */
+    public AbstractClient getClient() {
+        // Get the next client and raise the counter afterwards.
+        AbstractClient selectedClient = clients.get(nextClient++);
+        // Check if the nextClient counter is higher than the actual number of clients -
+        // If it is, reset it.
+        if (nextClient >= clients.size()) {
+            nextClient = 0;
+        }
+
+        return selectedClient;
+    }
+
+    /**
+     * Get all currently configured endpoints known to HiveJ.
+     */
+    public List<Endpoint> getEndpoints() {
+        ArrayList<Endpoint> endpoints = new ArrayList<>();
+        // Construct a list of all endpoints by iterating over all known clients.
+        for (AbstractClient client : clients) {
+            endpoints.add(client.getEndpoint());
+        }
+        return endpoints;
+    }
+
+}

--- a/core/src/main/java/org/operationcrypto/hivej/communication/ConnectionManager.java
+++ b/core/src/main/java/org/operationcrypto/hivej/communication/ConnectionManager.java
@@ -109,18 +109,22 @@ public class ConnectionManager {
      * Get one of the clients managed by the <code>ConnectionManager</code>. The
      * <code>ConnectionManager</code> uses the Round-Robin load balancing mechanism.
      * 
-     * @return
+     * @return The next available client.
+     * @throws Exception In case no client is available.
      */
-    public AbstractClient getClient() {
-        // Get the next client and raise the counter afterwards.
-        AbstractClient selectedClient = clients.get(nextClient++);
+    public AbstractClient getClient() throws Exception {
+        // Check if an endpoint is available.
+        if (clients == null || clients.isEmpty()) {
+            throw new Exception("No clients available.");
+        }
         // Check if the nextClient counter is higher than the actual number of clients -
         // If it is, reset it.
-        if (nextClient >= clients.size()) {
+        if (nextClient > clients.size()) {
             nextClient = 0;
         }
 
-        return selectedClient;
+        // Get the next client and raise the counter afterwards.
+        return clients.get(nextClient++);
     }
 
     /**

--- a/core/src/main/java/org/operationcrypto/hivej/communication/ConnectionManager.java
+++ b/core/src/main/java/org/operationcrypto/hivej/communication/ConnectionManager.java
@@ -119,7 +119,7 @@ public class ConnectionManager {
         }
         // Check if the nextClient counter is higher than the actual number of clients -
         // If it is, reset it.
-        if (nextClient > clients.size()) {
+        if (nextClient >= clients.size()) {
             nextClient = 0;
         }
 

--- a/core/src/main/java/org/operationcrypto/hivej/communication/Endpoint.java
+++ b/core/src/main/java/org/operationcrypto/hivej/communication/Endpoint.java
@@ -1,0 +1,83 @@
+/*
+ *     This file is part of HiveJ
+ * 
+ *     HiveJ is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * 
+ *     HiveJ is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ * 
+ *     You should have received a copy of the GNU General Public License
+ *     along with HiveJ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.operationcrypto.hivej.communication;
+
+import java.net.URL;
+
+/**
+ * This class is used to initialize a http request.
+ * 
+ * @author <a href="https://github.com/marvin-we">marvin-we</a>
+ */
+public class Endpoint {
+    private URL endpointURL;
+    private boolean disableSSLVerification;
+
+    /**
+     * Create a new Endpoint to communicate with.
+     * 
+     * @param endpointURL            The URL of the node to communicate with.
+     * @param disableSSLVerification Configure if the verification of SSL
+     *                               certificates should be disabled.
+     */
+    public Endpoint(URL endpointURL, Boolean disableSSLVerification) {
+        this.setEndpointURI(endpointURL);
+        this.setDisableSSLVerification(disableSSLVerification);
+    }
+
+    /**
+     * Get the configured URL.
+     * 
+     * @return The configured URL.
+     */
+    public URL getEndpointURL() {
+        return endpointURL;
+    }
+
+    /**
+     * Configure the URL to connect to.
+     * 
+     * @param endpointURL The URL to connect to.
+     */
+    public void setEndpointURI(URL endpointURL) {
+        this.endpointURL = endpointURL;
+    }
+
+    /**
+     * Get the information if the SSL verification is disabled for this endpoint.
+     * 
+     * @return The information if the SSL verification is disabled for this
+     *         endpoint.
+     */
+    public boolean getDisableSSLVerification() {
+        return disableSSLVerification;
+    }
+
+    /**
+     * Define if the SSL verification is disabled for this endpoint.
+     * 
+     * @param disableSSLVerification Set to <code>true</code> to disable the SSL
+     *                               verification or <code>false</code> to enable it
+     *                               (recommended!).
+     */
+    public void setDisableSSLVerification(Boolean disableSSLVerification) {
+        if (disableSSLVerification == null) {
+            this.disableSSLVerification = false;
+        }
+        this.disableSSLVerification = disableSSLVerification;
+    }
+}

--- a/core/src/main/java/org/operationcrypto/hivej/communication/HttpClient.java
+++ b/core/src/main/java/org/operationcrypto/hivej/communication/HttpClient.java
@@ -87,7 +87,7 @@ public class HttpClient extends AbstractClient {
     }
 
     @Override
-    public JsonRPCResponse invokeAndReadResponse(JsonRPCRequest requestObject) throws Exception {
+    public JsonRPCResponse invokeAndReadResponse(JsonRPCRequest requestObject) throws IOException {
         try {
             String requestPayload = requestObject.toJson();
             HttpRequest httpRequest = requestFactory.buildPostRequest(
@@ -115,7 +115,7 @@ public class HttpClient extends AbstractClient {
             }
 
         } catch (IOException e) {
-            throw new Exception("A problem occured while processing the request.", e);
+            throw new IOException("A problem occured while processing the request.", e);
         }
     }
 

--- a/core/src/main/java/org/operationcrypto/hivej/communication/HttpClient.java
+++ b/core/src/main/java/org/operationcrypto/hivej/communication/HttpClient.java
@@ -17,8 +17,16 @@
 package org.operationcrypto.hivej.communication;
 
 import java.io.IOException;
-import java.net.URI;
+import java.net.URL;
 import java.security.GeneralSecurityException;
+import java.util.UUID;
+
+import com.google.api.client.http.ByteArrayContent;
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.javanet.NetHttpTransport;
 
 import org.apache.http.client.ClientProtocolException;
 import org.operationcrypto.hivej.jrpc.JsonRPCRequest;
@@ -26,49 +34,87 @@ import org.operationcrypto.hivej.jrpc.JsonRPCResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.api.client.http.ByteArrayContent;
-import com.google.api.client.http.GenericUrl;
-import com.google.api.client.http.HttpRequest;
-import com.google.api.client.http.HttpResponse;
-import com.google.api.client.http.javanet.NetHttpTransport;
-
 /**
  * This class handles the communication to a Hive Node using the HTTP protocol.
  * 
  * @author <a href="https://github.com/marvin-we">marvin-we</a>
  */
-public class HttpClient implements AbstractClient {
+public class HttpClient extends AbstractClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpClient.class);
+    private final String CLIENT_ID;
+
+    /**
+     * This field stores the connection factory used for requests against the given
+     * endpoint.
+     */
+    private HttpRequestFactory requestFactory;
+
+    /**
+     * Initialize a new Http Client.
+     * 
+     * @param endpointURL            The endpoint to connect to.
+     * @param disableSSLVerification Configure if the SSL certificate validation
+     *                               should be skipped.
+     * @throws Exception In case the request factory could not be setup.
+     */
+    public HttpClient(URL endpointURL, boolean disableSSLVerification) throws Exception {
+        this(new Endpoint(endpointURL, disableSSLVerification));
+    }
+
+    /**
+     * Initialize a new Http Client.
+     * 
+     * @param endpoint The <code>Endpoint</code> this client connects to.
+     * @throws Exception In case the request factory could not be setup.
+     */
+    public HttpClient(Endpoint endpoint) throws Exception {
+        this.setEndpoint(endpoint);
+
+        // Generate a unique client id for easier logging.
+        CLIENT_ID = this.getEndpoint().getEndpointURL() + "-" + UUID.randomUUID();
+
+        NetHttpTransport.Builder builder = new NetHttpTransport.Builder();
+        requestFactory = builder.build().createRequestFactory(new HttpClientRequestInitializer());
+        // Disable SSL verification if needed
+        if (this.getEndpoint().getDisableSSLVerification()
+                && this.getEndpoint().getEndpointURL().getProtocol().equals("https")) {
+            try {
+                builder.doNotValidateCertificate();
+            } catch (GeneralSecurityException e) {
+                throw new Exception("Could not initialize request builder.", e);
+            }
+        }
+    }
 
     @Override
-    public JsonRPCResponse invokeAndReadResponse(JsonRPCRequest requestObject, URI endpointUri,
-            boolean sslVerificationDisabled) throws Exception {
+    public JsonRPCResponse invokeAndReadResponse(JsonRPCRequest requestObject) throws Exception {
         try {
-            NetHttpTransport.Builder builder = new NetHttpTransport.Builder();
-            // Disable SSL verification if needed
-            if (sslVerificationDisabled && endpointUri.getScheme().equals("https")) {
-                builder.doNotValidateCertificate();
-            }
-
             String requestPayload = requestObject.toJson();
-            HttpRequest httpRequest = builder.build().createRequestFactory(new HttpClientRequestInitializer())
-                    .buildPostRequest(new GenericUrl(endpointUri),
-                            ByteArrayContent.fromString("application/json", requestPayload));
+            HttpRequest httpRequest = requestFactory.buildPostRequest(
+                    new GenericUrl(this.getEndpoint().getEndpointURL()),
+                    ByteArrayContent.fromString("application/json", requestPayload));
 
-            LOGGER.debug("Sending {}.", requestPayload);
+            LOGGER.debug("Client {} send {}.", CLIENT_ID, requestPayload);
 
             HttpResponse httpResponse = httpRequest.execute();
+            try {
+                int status = httpResponse.getStatusCode();
+                String responsePayload = httpResponse.parseAsString();
 
-            int status = httpResponse.getStatusCode();
-            String responsePayload = httpResponse.parseAsString();
-
-            if (status >= 200 && status < 300 && responsePayload != null) {
-                return new JsonRPCResponse(CommunicationHandler.getObjectMapper().readTree(responsePayload));
-            } else {
-                throw new ClientProtocolException("Unexpected response status: " + status);
+                if (status >= 200 && status < 300 && responsePayload != null) {
+                    JsonRPCResponse rawJsonResponse = new JsonRPCResponse(
+                            CommunicationHandler.getObjectMapper().readTree(responsePayload));
+                    LOGGER.debug("Client {} received {} ", CLIENT_ID, rawJsonResponse);
+                    return rawJsonResponse;
+                } else {
+                    throw new ClientProtocolException("Unexpected response status: " + status);
+                }
+            } finally {
+                // Close the response if no longer needed.
+                httpResponse.disconnect();
             }
 
-        } catch (GeneralSecurityException | IOException e) {
+        } catch (IOException e) {
             throw new Exception("A problem occured while processing the request.", e);
         }
     }

--- a/core/src/test/java/communication/DatabaseAPITest.java
+++ b/core/src/test/java/communication/DatabaseAPITest.java
@@ -47,7 +47,7 @@ import org.operationcrypto.hivej.jrpc.JsonRPCRequest;
 
 public class DatabaseAPITest {
 	@BeforeClass
-	public void initTests() {
+	public static void initTests() {
 		// FIXME: Need to initiate the config once to make sure an endpoint is added.
 		HiveJConfig.getInstance();
 	}

--- a/core/src/test/java/communication/DatabaseAPITest.java
+++ b/core/src/test/java/communication/DatabaseAPITest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.operationcrypto.hivej.api.database.model.Account;
 import org.operationcrypto.hivej.api.database.model.FindAccountRecoveryRequestsArgs;
@@ -39,13 +40,21 @@ import org.operationcrypto.hivej.api.database.model.GetVersionReturn;
 import org.operationcrypto.hivej.api.database.model.RewardBalance;
 import org.operationcrypto.hivej.api.database.model.Vote;
 import org.operationcrypto.hivej.communication.CommunicationHandler;
+import org.operationcrypto.hivej.config.HiveJConfig;
 import org.operationcrypto.hivej.enums.HiveApiType;
 import org.operationcrypto.hivej.enums.RequestMethod;
 import org.operationcrypto.hivej.jrpc.JsonRPCRequest;
 
 public class DatabaseAPITest {
+	@BeforeClass
+	public void initTests() {
+		// FIXME: Need to initiate the config once to make sure an endpoint is added.
+		HiveJConfig.getInstance();
+	}
+
 	/**
-	 * Tests the database api find votes request and response by passing a user and permlink.
+	 * Tests the database api find votes request and response by passing a user and
+	 * permlink.
 	 * 
 	 * @throws Throwable
 	 */
@@ -54,12 +63,12 @@ public class DatabaseAPITest {
 		String permlink = "steemj-dev-diary-9-14-01-2018";
 		String author = "dez1337";
 		FindVotesArgs args = new FindVotesArgs(author, permlink);
-		
+
 		JsonRPCRequest request = new JsonRPCRequest(HiveApiType.DATABASE_API, RequestMethod.FIND_VOTES, args);
 
 		CommunicationHandler communicationHandler = new CommunicationHandler();
 		FindVotesReturn result = communicationHandler.performRequest(request, FindVotesReturn.class).get(0);
-		
+
 		Vote vote = result.getVotes().get(0);
 		assertEquals(permlink, vote.getPermlink());
 		assertEquals(author, vote.getAuthor());
@@ -70,16 +79,15 @@ public class DatabaseAPITest {
 		assertEquals(0, vote.getNumChanges());
 		assertEquals("2018-01-14T15:50:09", vote.getLastUpdate());
 	}
-	
+
 	/**
 	 * Tests the database api get reward funds request (no parameters) and response.
 	 * 
 	 * @throws Throwable
-	 */	
+	 */
 	@Test
 	public void testGetRewardFunds() throws Throwable {
-		JsonRPCRequest request = new JsonRPCRequest(HiveApiType.DATABASE_API, RequestMethod.GET_REWARD_FUNDS,
-				null);
+		JsonRPCRequest request = new JsonRPCRequest(HiveApiType.DATABASE_API, RequestMethod.GET_REWARD_FUNDS, null);
 
 		CommunicationHandler communicationHandler = new CommunicationHandler();
 		GetRewardFundsReturn result = communicationHandler.performRequest(request, GetRewardFundsReturn.class).get(0);
@@ -99,7 +107,7 @@ public class DatabaseAPITest {
 		assertNotNull(fund.getContentConstant());
 		assertNotNull(fund.getCurationRewardCurve());
 	}
-	
+
 	/**
 	 * Tests the database api get version request and response.
 	 * 
@@ -107,9 +115,8 @@ public class DatabaseAPITest {
 	 */
 	@Test
 	public void testGetVersion() throws Throwable {
-		JsonRPCRequest request = new JsonRPCRequest(HiveApiType.DATABASE_API, RequestMethod.GET_VERSION,
-				null);
-		
+		JsonRPCRequest request = new JsonRPCRequest(HiveApiType.DATABASE_API, RequestMethod.GET_VERSION, null);
+
 		CommunicationHandler communicationHandler = new CommunicationHandler();
 		GetVersionReturn result = communicationHandler.performRequest(request, GetVersionReturn.class).get(0);
 
@@ -118,27 +125,26 @@ public class DatabaseAPITest {
 		assertNotNull(result.getFcRevision());
 		assertNotNull(result.getSteemRevision());
 	}
-	
+
 	/**
 	 * Tests the database api find owner history request and response
 	 * 
 	 * @throws Throwable
-	 */	
+	 */
 	@Test
 	public void testFindOwnerHistories() throws Throwable {
 		FindOwnerHistoriesArgs args = new FindOwnerHistoriesArgs();
 		args.setOwner("hiveio");
-		
-		JsonRPCRequest request = new JsonRPCRequest(HiveApiType.DATABASE_API, RequestMethod.FIND_OWNER_HISTORIES,
-				args);
-		
+
+		JsonRPCRequest request = new JsonRPCRequest(HiveApiType.DATABASE_API, RequestMethod.FIND_OWNER_HISTORIES, args);
+
 		CommunicationHandler communicationHandler = new CommunicationHandler();
 		FindOwnerHistoriesReturn result = communicationHandler.performRequest(request, FindOwnerHistoriesReturn.class)
 				.get(0);
-		
+
 		assertNotNull(result.getOwnerAuths());
 	}
-	
+
 	/**
 	 * Tests the database api find account recovery requests request and response.
 	 * 
@@ -148,17 +154,17 @@ public class DatabaseAPITest {
 	public void testFindAccountRecoveryRequests() throws Throwable {
 		FindAccountRecoveryRequestsArgs args = new FindAccountRecoveryRequestsArgs();
 		args.setAccounts(Collections.singletonList("hiveio"));
-		
-		JsonRPCRequest request = new JsonRPCRequest(HiveApiType.DATABASE_API, RequestMethod.FIND_ACCOUNT_RECOVERY_REQUESTS,
-				args);
-		
+
+		JsonRPCRequest request = new JsonRPCRequest(HiveApiType.DATABASE_API,
+				RequestMethod.FIND_ACCOUNT_RECOVERY_REQUESTS, args);
+
 		CommunicationHandler communicationHandler = new CommunicationHandler();
 		FindAccountRecoveryRequestsReturn result = communicationHandler
 				.performRequest(request, FindAccountRecoveryRequestsReturn.class).get(0);
-		
+
 		assertNotNull(result);
 	}
-	
+
 	/**
 	 * Tests the database api find accounts request and response.
 	 * 
@@ -202,4 +208,3 @@ public class DatabaseAPITest {
 		assertNotNull(account.getVestingShares());
 	}
 }
- 

--- a/sample/src/main/java/org/operationcrypto/hivej/samples/HandleMultipleConnections.java
+++ b/sample/src/main/java/org/operationcrypto/hivej/samples/HandleMultipleConnections.java
@@ -1,0 +1,120 @@
+/*
+ *     This file is part of HiveJ
+ * 
+ *     HiveJ is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * 
+ *     HiveJ is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ * 
+ *     You should have received a copy of the GNU General Public License
+ *     along with HiveJ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.operationcrypto.hivej.samples;
+
+import java.net.URL;
+import java.util.List;
+
+import org.operationcrypto.hivej.api.database.model.FindVotesArgs;
+import org.operationcrypto.hivej.api.database.model.FindVotesReturn;
+import org.operationcrypto.hivej.communication.CommunicationHandler;
+import org.operationcrypto.hivej.communication.Endpoint;
+import org.operationcrypto.hivej.config.HiveJConfig;
+import org.operationcrypto.hivej.enums.HiveApiType;
+import org.operationcrypto.hivej.enums.RequestMethod;
+import org.operationcrypto.hivej.jrpc.JsonRPCRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This sample class shows and explains how to configure HiveJ to handle
+ * connections to multiple endpoints (http(s) and ws(s)).
+ * 
+ * @author <a href="https://github.com/marvin-we">marvin-we</a>
+ */
+public class HandleMultipleConnections {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HandleMultipleConnections.class);
+
+    private HandleMultipleConnections() {
+        // Do not initialize this sample.
+    }
+
+    /**
+     * Define multiple endpoints in various ways.
+     */
+    public static void main(String args[]) {
+        // Get an instance of the global config object.
+        HiveJConfig config = HiveJConfig.getInstance();
+
+        // By default, HiveJ is pre-configured with an endpoint.
+        List<Endpoint> currentlyConfiguredEndpoints = config.getEndpoints();
+        for (Endpoint endpoint : currentlyConfiguredEndpoints) {
+            LOGGER.info("Endpoint: {}", endpoint.getEndpointURL());
+        }
+
+        // HiveJ allows to configure multiple endpoints and will automatically
+        // loadbalance between the known endpoints.
+        try {
+            // Lets add a new HTTPs endpoint to connect to.
+            config.addEndpoint(new URL("https://api.hive.blog"));
+            /*
+             * Add another endpoint, but this time HiveJ should not validate the SSL
+             * certificates of the node.
+             * 
+             * Be careful! Disabling certificate validation is dangerous and should only be
+             * done in testing environments!
+             */
+
+            config.addEndpoint(new URL("https://api.openhive.network"), true);
+        } catch (Exception e) {
+            LOGGER.error("Could not transfer the given String into a valid URL.", e);
+        }
+
+        // Run 4 calls against the Hive node.
+        for (int i = 0; i < 4; i++) {
+            String permlink = "steemj-dev-diary-9-14-01-2018";
+            String author = "dez1337";
+
+            FindVotesArgs arguments = new FindVotesArgs(author, permlink);
+
+            JsonRPCRequest request = new JsonRPCRequest(HiveApiType.DATABASE_API, RequestMethod.FIND_VOTES, arguments);
+
+            CommunicationHandler communicationHandler = new CommunicationHandler();
+            try {
+                communicationHandler.performRequest(request, FindVotesReturn.class).get(0);
+            } catch (Exception e) {
+                LOGGER.error("Could not perform request.", e);
+            }
+        }
+        /*
+         * The logging config for this sample proejct (see
+         * /src/main/resources/log4j2.xml) is configured to show also DEBUG log
+         * messages.
+         * 
+         * Those detailed log messages include a unique id of the used client - The
+         * debug logs of the sample above should look like this:
+         * 
+         * [...] Client https://api.hive.blog/-7677fca2-b778-4040-bc87-4e0ae32db7d6 send
+         * / receive
+         * 
+         * [...] Client https://api.hive.blog-3bae0c5a-041d-4c33-87e1-f0ae1ff67845 send
+         * / receive
+         * 
+         * [...] Client
+         * https://api.openhive.network-4fba0916-bc8a-462d-9a84-4ef31f15f6c6 send /
+         * receive
+         * 
+         * [...] Client https://api.hive.blog/-7677fca2-b778-4040-bc87-4e0ae32db7d6 send
+         * / receive
+         * 
+         * In total, 4 requests have been initiated, while 3 clients were configured
+         * (the pre-configured endpoint and the two added by this sample).
+         * 
+         * Request | Client 1 | 1 2 | 2 3 | 3 4 | 1 5 | 2 ... | ...
+         */
+    }
+}

--- a/sample/src/main/resources/log4j2.xml
+++ b/sample/src/main/resources/log4j2.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+      This file is part of SteemJ (formerly known as 'Steem-Java-Api-Wrapper')
+  
+      SteemJ is free software: you can redistribute it and/or modify
+      it under the terms of the GNU General Public License as published by
+      the Free Software Foundation, either version 3 of the License, or
+      (at your option) any later version.
+  
+      SteemJ is distributed in the hope that it will be useful,
+      but WITHOUT ANY WARRANTY; without even the implied warranty of
+      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+      GNU General Public License for more details.
+  
+      You should have received a copy of the GNU General Public License
+      along with SteemJ.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<Configuration status="info">
+	<Appenders>
+		<Console name="Console" target="SYSTEM_OUT">
+			<PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
+		</Console>
+	</Appenders>
+	<Loggers>
+		<Root level="debug">
+			<AppenderRef ref="Console" />
+		</Root>
+	</Loggers>
+</Configuration>

--- a/sample/src/main/resources/log4j2.xml
+++ b/sample/src/main/resources/log4j2.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-      This file is part of SteemJ (formerly known as 'Steem-Java-Api-Wrapper')
+      This file is part of HiveJ
   
-      SteemJ is free software: you can redistribute it and/or modify
+      HiveJ is free software: you can redistribute it and/or modify
       it under the terms of the GNU General Public License as published by
       the Free Software Foundation, either version 3 of the License, or
       (at your option) any later version.
   
-      SteemJ is distributed in the hope that it will be useful,
+      HiveJ is distributed in the hope that it will be useful,
       but WITHOUT ANY WARRANTY; without even the implied warranty of
       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
       GNU General Public License for more details.
   
       You should have received a copy of the GNU General Public License
-      along with SteemJ.  If not, see <http://www.gnu.org/licenses/>.
+      along with HiveJ.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <Configuration status="info">
 	<Appenders>


### PR DESCRIPTION
- Introduce an 'Endpoint' class that stores the URL and some settings
- Introduce a 'ConnectionManager' which creates a Client for each Endpoint and that balances requests between those clients using round robin
- Let the 'CommunicationHandler' use the 'ConnectionManager'
- Make Endpoints configurable in the 'HiveJConfig'
- Add a show case to the sample project including some explanations

Fixes #14

Please review and merge.