### PR TITLE
Refactor singletons

### DIFF
--- a/core/src/main/java/org/operationcrypto/hivej/communication/ConnectionManager.java
+++ b/core/src/main/java/org/operationcrypto/hivej/communication/ConnectionManager.java
@@ -32,6 +32,8 @@ import org.slf4j.LoggerFactory;
  */
 public class ConnectionManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConnectionManager.class);
+    /** Pattern to identify the HTTP protocol */
+    private static final String HTTP_PROTOCOL_PATTERN = "(http){1}[s]?"
 
     /** The one and only instance. */
     private static volatile ConnectionManager sConnectionManager;
@@ -79,7 +81,7 @@ public class ConnectionManager {
      * @throws Exception In case the client could not be initialized.
      */
     public void addClient(Endpoint endpoint) throws Exception {
-        if (endpoint.getEndpointURL().getProtocol().toLowerCase().matches("(http){1}[s]?")) {
+        if (endpoint.getEndpointURL().getProtocol().toLowerCase().matches(HTTP_PROTOCOL_PATTERN)) {
             this.clients.add(new HttpClient(endpoint));
         } else {
             throw new InvalidParameterException("No client implementation for the following protocol available: "

--- a/core/src/main/java/org/operationcrypto/hivej/communication/ConnectionManager.java
+++ b/core/src/main/java/org/operationcrypto/hivej/communication/ConnectionManager.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 public class ConnectionManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConnectionManager.class);
     /** Pattern to identify the HTTP protocol */
-    private static final String HTTP_PROTOCOL_PATTERN = "(http){1}[s]?"
+    private static final String HTTP_PROTOCOL_PATTERN = "(http){1}[s]?";
 
     /** The one and only instance. */
     private static volatile ConnectionManager sConnectionManager;

--- a/core/src/main/java/org/operationcrypto/hivej/config/HiveJConfig.java
+++ b/core/src/main/java/org/operationcrypto/hivej/config/HiveJConfig.java
@@ -31,6 +31,9 @@ public class HiveJConfig {
 	/** The default endpoint URI */
 	private static final String DEFAULT_HIVE_API_URI = "https://api.hive.blog/";
 
+	/** The one and only instance. */
+	private static volatile HiveJConfig sHiveJConfig;
+
 	/** Configure the encoding for e.g. comments. */
 	private Charset encodingCharset;
 	/** Configure the maximum time the client should wait for an HTTP response. */
@@ -41,25 +44,15 @@ public class HiveJConfig {
 	 */
 	private int connectionTimeout;
 
-	private static HiveJConfig sHiveJConfig;
-
-	/**
-	 * Returns the singleton instance HiveJConfigurationObject
-	 * 
-	 * @return HiveJConfig
-	 */
-	public static HiveJConfig getInstance() {
-		if (sHiveJConfig == null) {
-			sHiveJConfig = new HiveJConfig();
-		}
-		return sHiveJConfig;
-	}
-
 	/**
 	 * Create a new <code>HiveJConfig</code> prefilled with default values.
 	 */
 	private HiveJConfig() {
-		super();
+		// Make sure the internal instance can only be initialized once, even if
+		// reflection is used.
+		if (sHiveJConfig != null) {
+			throw new RuntimeException("Use getInstance() method to get the single instance of this class.");
+		}
 
 		this.setResponseTimeout(1000);
 		this.setConnectionTimeout(2000);
@@ -70,6 +63,22 @@ public class HiveJConfig {
 			LOGGER.error("Could not create a URL object from the default hive URL.", e);
 		}
 
+	}
+
+	/**
+	 * Returns the singleton instance HiveJConfigurationObject
+	 * 
+	 * @return HiveJConfig
+	 */
+	public static synchronized HiveJConfig getInstance() {
+		// Double-checked locking pattern
+		if (sHiveJConfig == null) {
+			synchronized (HiveJConfig.class) {
+				if (sHiveJConfig == null)
+					sHiveJConfig = new HiveJConfig();
+			}
+		}
+		return sHiveJConfig;
 	}
 
 	/**


### PR DESCRIPTION
**Based on #15 - Review and merge that one first!**

Fixes #21

Refactors both Singletons ('HiveJConfig' and 'ConnectionManager') to:
- Protect them from reflection by throwing a RuntimeException in case the constructor is called again
- Make the 'getInstance' method 'synchronized'.
There is one difference between both Singletons now: 'HiveJConfig' now uses eager initialization, as with #15, the HiveJConfig is the only place that adds endpoints to the ConnectionManager so it always needs to be initialized (solves the fixme in the tests too). The 'ConnectionManager' is still "lazy loading".

The following points are open for discussion:
- Usage of 'violate' results in https://wiki.sei.cmu.edu/confluence/display/java/CON50-J.+Do+not+assume+that+declaring+a+reference+volatile+guarantees+safe+publication+of+the+members+of+the+referenced+object beeing raised by SQ - There are some discussion around it (e.g. https://community.sonarsource.com/t/s3077-question-in-sonarqube-7-5/9818 ). Should we go for the enum based singleton as suggested there? Do you know if the raised SQ issue is valid?
- Our singletons do not need to be 'Serializable' for now (?)