### PR TITLE
Move the default endpoint creation to the ConnectionManager

### DIFF
--- a/core/src/main/java/org/operationcrypto/hivej/communication/ConnectionManager.java
+++ b/core/src/main/java/org/operationcrypto/hivej/communication/ConnectionManager.java
@@ -17,6 +17,7 @@
 package org.operationcrypto.hivej.communication;
 
 import java.io.IOException;
+import java.net.URL;
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +33,8 @@ import org.slf4j.LoggerFactory;
  */
 public class ConnectionManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConnectionManager.class);
+    /** The default endpoint URI */
+    private static final String DEFAULT_HIVE_API_URI = "https://api.hive.blog/";
 
     /** The one and only instance. */
     private static volatile ConnectionManager sConnectionManager;
@@ -53,6 +56,14 @@ public class ConnectionManager {
 
         this.nextClient = 0;
         this.clients = new CopyOnWriteArrayList<>();
+
+        try {
+            // Add the default endpoint so that the 'ConnectionManager ' is initialized with
+            // one valid connection.
+            this.addClient(new Endpoint(new URL(DEFAULT_HIVE_API_URI), false));
+        } catch (Exception e) {
+            LOGGER.error("Could not create a URL object from the default hive URL.", e);
+        }
     }
 
     /**

--- a/core/src/main/java/org/operationcrypto/hivej/config/HiveJConfig.java
+++ b/core/src/main/java/org/operationcrypto/hivej/config/HiveJConfig.java
@@ -28,9 +28,6 @@ import org.slf4j.LoggerFactory;
 public class HiveJConfig {
 	private static final Logger LOGGER = LoggerFactory.getLogger(HiveJConfig.class);
 
-	/** The default endpoint URI */
-	private static final String DEFAULT_HIVE_API_URI = "https://api.hive.blog/";
-
 	/** The one and only instance. */
 	private static volatile HiveJConfig sHiveJConfig;
 
@@ -56,13 +53,6 @@ public class HiveJConfig {
 
 		this.setResponseTimeout(1000);
 		this.setConnectionTimeout(2000);
-
-		try {
-			this.addEndpoint(new URL(DEFAULT_HIVE_API_URI));
-		} catch (Exception e) {
-			LOGGER.error("Could not create a URL object from the default hive URL.", e);
-		}
-
 	}
 
 	/**

--- a/core/src/main/java/org/operationcrypto/hivej/config/HiveJConfig.java
+++ b/core/src/main/java/org/operationcrypto/hivej/config/HiveJConfig.java
@@ -31,6 +31,9 @@ public class HiveJConfig {
 	/** The default endpoint URI */
 	private static final String DEFAULT_HIVE_API_URI = "https://api.hive.blog/";
 
+	/** The one and only instance. */
+	private static volatile HiveJConfig sHiveJConfig;
+
 	/** Configure the encoding for e.g. comments. */
 	private Charset encodingCharset;
 	/** Configure the maximum time the client should wait for an HTTP response. */
@@ -41,25 +44,15 @@ public class HiveJConfig {
 	 */
 	private int connectionTimeout;
 
-	private static HiveJConfig sHiveJConfig;
-
-	/**
-	 * Returns the singleton instance HiveJConfigurationObject
-	 * 
-	 * @return HiveJConfig
-	 */
-	public static HiveJConfig getInstance() {
-		if (sHiveJConfig == null) {
-			sHiveJConfig = new HiveJConfig();
-		}
-		return sHiveJConfig;
-	}
-
 	/**
 	 * Create a new <code>HiveJConfig</code> prefilled with default values.
 	 */
 	private HiveJConfig() {
-		super();
+		// Make sure the internal instance can only be initialized once, even if
+		// reflection is used.
+		if (sHiveJConfig != null) {
+			throw new RuntimeException("Use getInstance() method to get the single instance of this class.");
+		}
 
 		this.setResponseTimeout(1000);
 		this.setConnectionTimeout(2000);
@@ -70,6 +63,22 @@ public class HiveJConfig {
 			LOGGER.error("Could not create a URL object from the default hive URL.", e);
 		}
 
+	}
+
+	/**
+	 * Returns the singleton instance HiveJConfigurationObject
+	 * 
+	 * @return HiveJConfig
+	 */
+	public static synchronized HiveJConfig getInstance() {
+		// Double-checked locking pattern
+		if (sHiveJConfig == null) {
+			synchronized (HiveJConfig.class) {
+				if (sHiveJConfig == null)
+					sHiveJConfig = new HiveJConfig();
+			}
+		}
+		return sHiveJConfig;
 	}
 
 	/**

--- a/core/src/test/java/communication/DatabaseAPITest.java
+++ b/core/src/test/java/communication/DatabaseAPITest.java
@@ -46,12 +46,6 @@ import org.operationcrypto.hivej.enums.RequestMethod;
 import org.operationcrypto.hivej.jrpc.JsonRPCRequest;
 
 public class DatabaseAPITest {
-	@BeforeClass
-	public static void initTests() {
-		// FIXME: Need to initiate the config once to make sure an endpoint is added.
-		HiveJConfig.getInstance();
-	}
-
 	/**
 	 * Tests the database api find votes request and response by passing a user and
 	 * permlink.


### PR DESCRIPTION
Based on #26 - Review and merge that one first

Fixes #25 

This solves #26 by moving the default endpoint and the client creation to the constructor of the 'ConnectionManager' to avoid that HiveJConfig has to be called/initialized.

Still a bit unsure if this is a propper design or if we should just skip the idea of a default endpoint and let the enduser add those.